### PR TITLE
Add doap.xml

### DIFF
--- a/doap.xml
+++ b/doap.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+         xmlns='http://usefulinc.com/ns/doap#'
+         xmlns:xmpp='https://linkmauve.fr/ns/xmpp-doap#'
+         xmlns:schema='https://schema.org/'>
+    <Project>
+        <name>stravaganza</name>
+        <shortdesc xml:lang='en'>Go XMPP library</shortdesc>
+        <homepage rdf:resource='https://github.com/jackal-xmpp/stravaganza'/>
+        <download-page rdf:resource='https://github.com/jackal-xmpp/stravaganza/releases'/>
+        <bug-database rdf:resource='https://github.com/jackal-xmpp/stravaganza/issues'/>
+        <license rdf:resource='https://github.com/jackal-xmpp/stravaganza/blob/master/LICENSE'/>
+        <language>en</language>
+        <programming-language>Go</programming-language>
+        <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-library'/>
+        <repository>
+            <GitRepository>
+                <browse rdf:resource='https://github.com/jackal-xmpp/stravaganza'/>
+                <location rdf:resource='https://github.com/jackal-xmpp/stravaganza.git'/>
+            </GitRepository>
+        </repository>
+        <implements rdf:resource='https://xmpp.org/rfcs/rfc5122.html'/>
+        <implements rdf:resource='https://xmpp.org/rfcs/rfc6120.html'/>
+        <implements rdf:resource='https://xmpp.org/rfcs/rfc6121.html'/>
+        <implements rdf:resource='https://xmpp.org/rfcs/rfc7590.html'/>
+        <implements rdf:resource='https://xmpp.org/rfcs/rfc7622.html'/>
+
+        <implements>
+            <xmpp:SupportedXep>
+                <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0115.html'/>
+                <xmpp:status>complete</xmpp:status>
+            </xmpp:SupportedXep>
+        </implements>
+    </Project>
+</rdf:RDF>

--- a/doap.xml
+++ b/doap.xml
@@ -12,6 +12,9 @@
         <license rdf:resource='https://github.com/jackal-xmpp/stravaganza/blob/master/LICENSE'/>
         <language>en</language>
         <programming-language>Go</programming-language>
+        <os>Linux</os>
+        <os>macOS</os>
+        <os>Windows</os>
         <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-library'/>
         <repository>
             <GitRepository>


### PR DESCRIPTION
The doap.xml contains a list of supported XEPs. The XMPP.org reads the doap.xml and show it on https://xmpp.org/software/
E.g. open https://xmpp.org/software/qxmpp/ and click on "Show supported XEPs".